### PR TITLE
Implement HintSize only for Iterators

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,10 @@ pub trait HintSize {
     }
 }
 
-impl<I> HintSize for I {}
+impl<I> HintSize for I
+where
+    I: Iterator + Sized,
+{}
 
 impl<I> Iterator for SizeHint<I>
 where


### PR DESCRIPTION
This makes the HintSize trait automatically implemented only for Sized Iterator instead of every possible type.