### PR TITLE
Improve size_hint()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,14 @@ where
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let (_approx, exact) = self.iter.size_hint();
-        (self.hint, exact)
+        match self.iter.size_hint() {
+            (_lower, Some(upper)) if self.hint > upper => {
+                 (self.hint, None)
+            },
+            (_lower, upper) => {
+                (self.hint, upper)
+            },
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,9 +58,9 @@ mod tests {
         let i = numbers.into_iter();
         assert_eq!(i.size_hint(), (max, Some(max)));
         let i = i.hint_size(max * 2);
-        assert_eq!(i.size_hint(), (max * 2, Some(max)));
+        assert_eq!(i.size_hint(), (max * 2, None));
         let i = i.map(|a| a + 1).hint_size(max * 3);
-        assert_eq!(i.size_hint(), (max * 3, Some(max)));
+        assert_eq!(i.size_hint(), (max * 3, None));
         let numbers: Vec<_> = i.collect();
         assert_eq!(numbers.capacity(), max * 3);
     }


### PR DESCRIPTION
This makes size_hint() return (self.hint, None) if the self.iter upper bound is less than self.hint, since in that case the exact upper bound is not known anymore.

From the [size_hint()](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.size_hint) documentation:
> The second half of the tuple that is returned is an `Option<usize>`. A `None` here means that either there is no known upper bound, or the upper bound is larger than usize.